### PR TITLE
fix(deps): resolve RUSTSEC-2026-0193, RUSTSEC-2026-0185, RUSTSEC-2026-0190, RUSTSEC-2026-0173

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,14 +46,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
 dependencies = [
- "cssparser 0.35.0",
- "html5ever 0.35.0",
+ "cssparser 0.37.0",
+ "html5ever 0.39.0",
  "maplit",
- "tendril",
  "url",
 ]
 
@@ -80,9 +79,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -775,7 +774,6 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "validator",
  "windows-sys 0.59.0",
  "yrs",
  "zeroize",
@@ -1203,14 +1201,12 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
- "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.3",
  "smallvec",
 ]
 
@@ -1226,36 +1222,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1273,22 +1245,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -1967,7 +1928,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2738,18 +2699,17 @@ dependencies = [
  "log",
  "mac",
  "markup5ever 0.14.1",
- "match_token 0.1.0",
+ "match_token",
 ]
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
- "markup5ever 0.35.0",
- "match_token 0.35.0",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -3581,19 +3541,19 @@ dependencies = [
  "log",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
- "tendril",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
 ]
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
- "tendril",
+ "tendril 0.5.0",
  "web_atoms",
 ]
 
@@ -3602,17 +3562,6 @@ name = "match_token"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4276,7 +4225,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_macros 0.10.0",
+ "phf_macros",
  "phf_shared 0.10.0",
  "proc-macro-hack",
 ]
@@ -4287,8 +4236,17 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -4309,6 +4267,16 @@ checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -4342,6 +4310,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4353,19 +4331,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4391,6 +4356,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
 ]
@@ -4604,28 +4578,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4741,9 +4693,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -5693,6 +5645,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot 0.12.5",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "string_cache_codegen"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5705,10 +5669,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
+name = "string_cache_codegen"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "subsecond"
@@ -5918,6 +5888,16 @@ checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
 dependencies = [
  "futf",
  "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -6586,36 +6566,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "validator"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
-dependencies = [
- "idna",
- "once_cell",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "validator_derive",
-]
-
-[[package]]
-name = "validator_derive"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
-dependencies = [
- "darling 0.20.11",
- "once_cell",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6863,14 +6813,14 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Error handling
-anyhow = "1.0"
+# anyhow >= 1.0.103 required: fixes RUSTSEC-2026-0190 (unsoundness in
+# `Error::downcast_mut()` after `Error::context`).
+anyhow = ">=1.0.103"
 thiserror = "1.0"
 
 # Logging & Observability

--- a/communitas-core/Cargo.toml
+++ b/communitas-core/Cargo.toml
@@ -22,7 +22,7 @@ yrs = { version = "0.19", features = ["sync"] }
 
 # Markdown rendering and sanitization
 pulldown-cmark = "0.12"
-ammonia = "4.0"
+ammonia = "4.1.3"  # >=4.1.3 required: fixes RUSTSEC-2026-0193 (mXSS in MathML annotation-xml)
 
 # Async runtime
 tokio = { version = "1.39", features = ["full"] }
@@ -77,7 +77,6 @@ getrandom = "0.2"
 base64 = "0.22"
 regex = "1.10"
 lazy_static = "1.4"
-validator = { version = "0.20", features = ["derive"] }
 dirs = "5.0"
 keyring = "3.2"
 tempfile = "3.0"


### PR DESCRIPTION
## Summary

Resolves the daily Security Audit workflow failure (run 28693097088).

Four advisories addressed:

- **RUSTSEC-2026-0193** (ammonia 4.1.2) — mXSS in MathML `annotation-xml` encoding strip. Bump `ammonia = "4.1.3"` (was "4.0").
- **RUSTSEC-2026-0185** (quinn-proto 0.11.14) — Remote memory exhaustion via unbounded out-of-order stream reassembly. `cargo update -p quinn-proto` to 0.11.15.
- **RUSTSEC-2026-0190** (anyhow 1.0.102) — Unsoundness in `Error::downcast_mut()`. Bump workspace `anyhow = ">=1.0.103"`.
- **RUSTSEC-2026-0173** (proc-macro-error2 2.0.1) — unmaintained. Drop unused `validator = { version = "0.20", features = ["derive"] }` dep from communitas-core (no source uses it; verified across the workspace).

## Pre-submit

- `cargo fmt --check --all`: clean
- `cargo check --workspace --all-features`: clean
- `cargo clippy --workspace --all-features -- -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic`: clean (matches security-audit.yml step)
- `cargo audit --ignore RUSTSEC-2025-0008 --ignore RUSTSEC-2024-0370`: exit 0 with 16 warnings (was: error "2 vulnerabilities found", 18 warnings before)

## Notes

- The validator crate removal is covered by a workspace-wide search: zero `use validator`/`validator::`/`#[derive(Validate)]` references in source.
- ammonia's pin change is a same-major bump (4.x line); no API changes expected.
- All edits are dependency-bumps and one unused-dep removal. No `.rs` source changes.
- This addresses the 4 advisories that produced today's "error: 2 vulnerabilities found; warning: 18 allowed warnings found" — but in reality there were also warnings about the updated versions that don't fail CI. Pre-existing ignored warnings (RUSTSEC-2025-0008, RUSTSEC-2024-0370) remain.

## Test Plan
- [x] Local audit exit 0
- [x] Local fmt/clippy/check clean
- [ ] Security Audit workflow run on this PR expected to turn green

Refs: https://github.com/saorsa-labs/communitas/actions/runs/28693097088
Refs: https://rustsec.org/advisories/RUSTSEC-2026-0193
Refs: https://rustsec.org/advisories/RUSTSEC-2026-0185
Refs: https://rustsec.org/advisories/RUSTSEC-2026-0190
Refs: https://rustsec.org/advisories/RUSTSEC-2026-0173

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates dependency versions to address RustSec advisories.

- Raises the workspace `anyhow` requirement to `>=1.0.103`.
- Pins `communitas-core` to `ammonia 4.1.3`.
- Refreshes the lockfile for `quinn-proto`, sanitizer parser crates, and related transitives.
- Removes the unused `validator` dependency from `communitas-core`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after checking the separate e2e dependency path.

- The main workspace changes are dependency-only.
- No blocking issue was found in the changed manifests or lockfile.
- The remaining note is limited to an independent e2e package lockfile.

communitas-dioxus/tests/e2e dependency lockfile

<details open><summary><h3>Security Review</h3></summary>

The main workspace dependency updates address the listed advisories. One separate e2e lockfile path may still carry the old `anyhow` version if audited or tested independently.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates the workspace `anyhow` requirement to the fixed lower bound. |
| communitas-core/Cargo.toml | Pins `ammonia` to the fixed release and removes an unused `validator` dependency. |
| Cargo.lock | Refreshes locked dependency versions and removes validator-related transitive packages. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Cargo.toml:34
**Standalone Lockfile Remains Vulnerable**

This raises the workspace `anyhow` floor, but the separate e2e package still has its own lockfile at `anyhow 1.0.102` and does not inherit this setting. When those tests or their audit run from that package directory, they can still resolve the version affected by the advisory this PR is meant to clear.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(deps): resolve RUSTSEC-2026-0193, RU..."](https://github.com/saorsa-labs/communitas/commit/81085ffe0f46a94f9f859fa259ff5a3699014616) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41794324)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - .cursorrules ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/communitas/-/custom-context?memory=2cdb34b9-d63e-4956-8691-e5be5916d295))
- Context used - CLAUDE.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/communitas/-/custom-context?memory=4119c055-1be9-452d-8ee9-c1d4dca0944d))

<!-- /greptile_comment -->